### PR TITLE
tests: service layer success and errors

### DIFF
--- a/tests/service/generate_password_service.py
+++ b/tests/service/generate_password_service.py
@@ -1,0 +1,20 @@
+from src.utility.password_checker import PasswordChecker
+
+from src.model.password import Password
+
+from src.generate.generate import Generate
+
+from src.exceptions.exceptions import PasswordCheckerException
+
+
+async def generate_password(password: dict) -> str:
+    payload = Password.parse_obj(password)
+
+    generate: Generate = Generate()
+
+    if not await PasswordChecker.check_password(password=payload):
+        raise PasswordCheckerException("generate length or generate params whole false")
+
+    new_password = await generate.generate_password(password=payload)
+
+    return new_password

--- a/tests/service/test_service_errors_layer.py
+++ b/tests/service/test_service_errors_layer.py
@@ -2,8 +2,6 @@ import pytest
 
 from src.exceptions.exceptions import PasswordCheckerException
 
-from src.model.password import Password
-
 from tests.mocks.passwords import (
     password_error_one,
     password_error_two,
@@ -18,16 +16,16 @@ from tests.service.generate_password_service import generate_password
 class TestServiceErrorsLayer:
     @pytest.mark.asyncio
     async def test_password_error_one(self) -> None:
-        pass_one = Password.parse_obj(password_error_one)
+        pass
 
     @pytest.mark.asyncio
     async def test_password_error_two(self) -> None:
-        pass_two = Password.parse_obj(password_error_two)
+        pass
 
     @pytest.mark.asyncio
     async def test_password_error_three(self) -> None:
-        pass_three = Password.parse_obj(password_error_three)
+        pass
 
     @pytest.mark.asyncio
     async def test_password_error_four(self) -> None:
-        pass_four = Password.parse_obj(password_error_four)
+        pass

--- a/tests/service/test_service_errors_layer.py
+++ b/tests/service/test_service_errors_layer.py
@@ -16,16 +16,20 @@ from tests.service.generate_password_service import generate_password
 class TestServiceErrorsLayer:
     @pytest.mark.asyncio
     async def test_password_error_one(self) -> None:
-        pass
+        with pytest.raises(PasswordCheckerException):
+            await generate_password(password_error_one)
 
     @pytest.mark.asyncio
     async def test_password_error_two(self) -> None:
-        pass
+        with pytest.raises(PasswordCheckerException):
+            await generate_password(password_error_two)
 
     @pytest.mark.asyncio
     async def test_password_error_three(self) -> None:
-        pass
+        with pytest.raises(PasswordCheckerException):
+            await generate_password(password_error_three)
 
     @pytest.mark.asyncio
     async def test_password_error_four(self) -> None:
-        pass
+        with pytest.raises(PasswordCheckerException):
+            await generate_password(password_error_four)

--- a/tests/service/test_service_errors_layer.py
+++ b/tests/service/test_service_errors_layer.py
@@ -16,4 +16,18 @@ from tests.service.generate_password_service import generate_password
 
 @pytest.mark.asyncio(scope="class")
 class TestServiceErrorsLayer:
-    pass
+    @pytest.mark.asyncio
+    async def test_password_error_one(self) -> None:
+        pass_one = Password.parse_obj(password_error_one)
+
+    @pytest.mark.asyncio
+    async def test_password_error_two(self) -> None:
+        pass_two = Password.parse_obj(password_error_two)
+
+    @pytest.mark.asyncio
+    async def test_password_error_three(self) -> None:
+        pass_three = Password.parse_obj(password_error_three)
+
+    @pytest.mark.asyncio
+    async def test_password_error_four(self) -> None:
+        pass_four = Password.parse_obj(password_error_four)

--- a/tests/service/test_service_errors_layer.py
+++ b/tests/service/test_service_errors_layer.py
@@ -1,0 +1,19 @@
+import pytest
+
+from src.exceptions.exceptions import PasswordCheckerException
+
+from src.model.password import Password
+
+from tests.mocks.passwords import (
+    password_error_one,
+    password_error_two,
+    password_error_three,
+    password_error_four
+)
+
+from tests.service.generate_password_service import generate_password
+
+
+@pytest.mark.asyncio(scope="class")
+class TestServiceErrorsLayer:
+    pass

--- a/tests/service/test_service_success_layer.py
+++ b/tests/service/test_service_success_layer.py
@@ -1,0 +1,19 @@
+import pytest
+
+from src.exceptions.exceptions import PasswordCheckerException
+
+from src.model.password import Password
+
+from tests.mocks.passwords import (
+    password_one,
+    password_two,
+    password_three,
+    password_four
+)
+
+from tests.service.generate_password_service import generate_password
+
+
+@pytest.mark.asyncio(scope="class")
+class TestServiceSuccessLayer:
+    pass

--- a/tests/service/test_service_success_layer.py
+++ b/tests/service/test_service_success_layer.py
@@ -1,7 +1,5 @@
 import pytest
 
-from src.exceptions.exceptions import PasswordCheckerException
-
 from src.model.password import Password
 
 from tests.mocks.passwords import (
@@ -16,4 +14,18 @@ from tests.service.generate_password_service import generate_password
 
 @pytest.mark.asyncio(scope="class")
 class TestServiceSuccessLayer:
-    pass
+    @pytest.mark.asyncio
+    async def test_password_service_success_one(self) -> None:
+        pass_one = Password.parse_obj(password_one)
+
+    @pytest.mark.asyncio
+    async def test_password_service_success_two(self) -> None:
+        pass_two = Password.parse_obj(password_two)
+
+    @pytest.mark.asyncio
+    async def test_password_service_success_three(self) -> None:
+        pass_three = Password.parse_obj(password_three)
+
+    @pytest.mark.asyncio
+    async def test_password_service_success_four(self) -> None:
+        pass_four = Password.parse_obj(password_four)

--- a/tests/service/test_service_success_layer.py
+++ b/tests/service/test_service_success_layer.py
@@ -1,7 +1,5 @@
 import pytest
 
-from src.model.password import Password
-
 from tests.mocks.passwords import (
     password_one,
     password_two,
@@ -16,16 +14,32 @@ from tests.service.generate_password_service import generate_password
 class TestServiceSuccessLayer:
     @pytest.mark.asyncio
     async def test_password_service_success_one(self) -> None:
-        pass_one = Password.parse_obj(password_one)
+        new_password = await generate_password(password_one)
+
+        assert new_password is not None
+        assert type(new_password) is str
+        assert len(new_password) == password_one["length"]
 
     @pytest.mark.asyncio
     async def test_password_service_success_two(self) -> None:
-        pass_two = Password.parse_obj(password_two)
+        new_password = await generate_password(password_two)
+
+        assert new_password is not None
+        assert type(new_password) is str
+        assert len(new_password) == password_two["length"]
 
     @pytest.mark.asyncio
     async def test_password_service_success_three(self) -> None:
-        pass_three = Password.parse_obj(password_three)
+        new_password = await generate_password(password_three)
+
+        assert new_password is not None
+        assert type(new_password) is str
+        assert len(new_password) == password_three["length"]
 
     @pytest.mark.asyncio
     async def test_password_service_success_four(self) -> None:
-        pass_four = Password.parse_obj(password_four)
+        new_password = await generate_password(password_four)
+
+        assert new_password is not None
+        assert type(new_password) is str
+        assert len(new_password) == password_four["length"]


### PR DESCRIPTION
- feat: use case about a edited version of service generate password
- tests: modules for success and erorr layers ready
- test: methods for success test case service
- test: layer error service methods assign
- test: service success case tests layer done
- chore: removed not used import from service error layer tests
- test: service layer errors case ready

I created the tests for success and errors from service application layer with an adaptation of function `generate_password` found in service module.
