### PR TITLE
tests: generate success and errors layer

### DIFF
--- a/src/generate/generate.py
+++ b/src/generate/generate.py
@@ -19,6 +19,18 @@ class Generate:
         self._special_char_2 = tuple(v for v in "<>^~¢£§¬")
 
     async def generate_password(self, password: Password) -> str | None:
+        not_none_keys = await get_not_none_keys(password=password)
+
+        valid_keys: tuple = tuple(v for v in not_none_keys)
+
+        new_password: str = len(valid_keys) > 0 and await self._join_str_password(
+            length=password.length,
+            valid_keys=valid_keys,
+        ) or ""
+
+        return new_password
+
+    async def _join_str_password(self, length: int, valid_keys: tuple[str]) -> str:
         data_to_select: dict = {
             "numbers": self._numbers,
             "low_case": self._low_case,
@@ -27,17 +39,13 @@ class Generate:
             "special_char_2": self._special_char_2,
         }
 
-        not_none_keys = await get_not_none_keys(password=password)
+        passwd = ""
 
-        valid_keys: tuple = tuple(v for v in not_none_keys)
-
-        new_password: str = ""
-
-        for _ in range(password.length):
+        for _ in range(length):
             chosen_key: str = choice(valid_keys)
 
             chosen_value: str = choice(data_to_select.get(chosen_key))
 
-            new_password += chosen_value
+            passwd += chosen_value
 
-        return new_password
+        return passwd

--- a/tests/generate/test_generate_errors_layer.py
+++ b/tests/generate/test_generate_errors_layer.py
@@ -1,0 +1,17 @@
+import pytest
+
+from src.model.password import Password
+
+from src.generate.generate import Generate
+
+from tests.mocks.passwords import (
+    password_error_one,
+    password_error_two,
+    password_error_three,
+    password_error_four
+)
+
+
+@pytest.mark.asyncio(scope="class")
+class TestGenerateErrorsLayer:
+    generate: Generate = Generate()

--- a/tests/generate/test_generate_errors_layer.py
+++ b/tests/generate/test_generate_errors_layer.py
@@ -18,16 +18,32 @@ class TestGenerateErrorsLayer:
 
     @pytest.mark.asyncio
     async def test_generate_password_error_one(self) -> None:
-        pass
+        pass_error_one = Password.parse_obj(password_error_one)
+
+        new_password = await self.generate.generate_password(pass_error_one)
+
+        assert len(new_password) == 0
 
     @pytest.mark.asyncio
     async def test_generate_password_error_two(self) -> None:
-        pass
+        pass_error_two = Password.parse_obj(password_error_two)
+
+        new_password = await self.generate.generate_password(pass_error_two)
+
+        assert len(new_password) == 0
 
     @pytest.mark.asyncio
     async def test_generate_password_error_three(self) -> None:
-        pass
+        pass_error_three = Password.parse_obj(password_error_three)
+
+        new_password = await self.generate.generate_password(pass_error_three)
+
+        assert len(new_password) == 0
 
     @pytest.mark.asyncio
     async def test_generate_password_error_four(self) -> None:
-        pass
+        pass_error_four = Password.parse_obj(password_error_four)
+
+        new_password = await self.generate.generate_password(pass_error_four)
+
+        assert len(new_password) == 0

--- a/tests/generate/test_generate_errors_layer.py
+++ b/tests/generate/test_generate_errors_layer.py
@@ -15,3 +15,19 @@ from tests.mocks.passwords import (
 @pytest.mark.asyncio(scope="class")
 class TestGenerateErrorsLayer:
     generate: Generate = Generate()
+
+    @pytest.mark.asyncio
+    async def test_generate_password_error_one(self) -> None:
+        pass
+
+    @pytest.mark.asyncio
+    async def test_generate_password_error_two(self) -> None:
+        pass
+
+    @pytest.mark.asyncio
+    async def test_generate_password_error_three(self) -> None:
+        pass
+
+    @pytest.mark.asyncio
+    async def test_generate_password_error_four(self) -> None:
+        pass

--- a/tests/generate/test_generate_success_layer.py
+++ b/tests/generate/test_generate_success_layer.py
@@ -5,13 +5,29 @@ from src.model.password import Password
 from src.generate.generate import Generate
 
 from tests.mocks.passwords import (
-    password_error_one,
-    password_error_two,
-    password_error_three,
-    password_error_four
+    password_one,
+    password_two,
+    password_three,
+    password_four
 )
 
 
 @pytest.mark.asyncio(scope="class")
 class TestGenerateSuccessful:
     generate: Generate = Generate()
+
+    @pytest.mark.asyncio
+    async def test_password_generate_success_one(self) -> None:
+        pass
+
+    @pytest.mark.asyncio
+    async def test_password_generate_success_two(self) -> None:
+        pass
+
+    @pytest.mark.asyncio
+    async def test_password_generate_success_three(self) -> None:
+        pass
+
+    @pytest.mark.asyncio
+    async def test_password_generate_success_four(self) -> None:
+        pass

--- a/tests/generate/test_generate_success_layer.py
+++ b/tests/generate/test_generate_success_layer.py
@@ -18,16 +18,40 @@ class TestGenerateSuccessful:
 
     @pytest.mark.asyncio
     async def test_password_generate_success_one(self) -> None:
-        pass
+        pass_one = Password.parse_obj(password_one)
+
+        new_password = await self.generate.generate_password(pass_one)
+
+        assert new_password is not None
+        assert type(new_password) is str
+        assert len(new_password) == pass_one.length
 
     @pytest.mark.asyncio
     async def test_password_generate_success_two(self) -> None:
-        pass
+        pass_two = Password.parse_obj(password_two)
+
+        new_password = await self.generate.generate_password(pass_two)
+
+        assert new_password is not None
+        assert type(new_password) is str
+        assert len(new_password) == pass_two.length
 
     @pytest.mark.asyncio
     async def test_password_generate_success_three(self) -> None:
-        pass
+        pass_three = Password.parse_obj(password_three)
+
+        new_password = await self.generate.generate_password(pass_three)
+
+        assert new_password is not None
+        assert type(new_password) is str
+        assert len(new_password) == pass_three.length
 
     @pytest.mark.asyncio
     async def test_password_generate_success_four(self) -> None:
-        pass
+        pass_four = Password.parse_obj(password_four)
+
+        new_password = await self.generate.generate_password(pass_four)
+
+        assert new_password is not None
+        assert type(new_password) is str
+        assert len(new_password) == pass_four.length

--- a/tests/generate/test_generate_success_layer.py
+++ b/tests/generate/test_generate_success_layer.py
@@ -1,0 +1,17 @@
+import pytest
+
+from src.model.password import Password
+
+from src.generate.generate import Generate
+
+from tests.mocks.passwords import (
+    password_error_one,
+    password_error_two,
+    password_error_three,
+    password_error_four
+)
+
+
+@pytest.mark.asyncio(scope="class")
+class TestGenerateSuccessful:
+    generate: Generate = Generate()

--- a/tests/routes/test_routes_success_layer.py
+++ b/tests/routes/test_routes_success_layer.py
@@ -21,7 +21,9 @@ API_URL_BASE = environ["API_URL_BASE_TEST"]
 @pytest.mark.asyncio(scope="class")
 class TestRoutesSuccessLayer:
     @pytest.mark.asyncio
-    async def test_generate_password_success_one(self) -> None:
+    async def test_routes_generate_password_success_one(self) -> None:
+        password_one["length"] = 32
+
         async with AsyncClient(app=app, base_url=API_URL_BASE) as client:
             response = await client.post(
                 url=URL,
@@ -31,7 +33,7 @@ class TestRoutesSuccessLayer:
             assert response.status_code == 201
 
     @pytest.mark.asyncio
-    async def test_generate_password_success_two(self) -> None:
+    async def test_routes_generate_password_success_two(self) -> None:
         async with AsyncClient(app=app, base_url=API_URL_BASE) as client:
             response = await client.post(
                 url=URL,
@@ -41,7 +43,7 @@ class TestRoutesSuccessLayer:
             assert response.status_code == 201
 
     @pytest.mark.asyncio
-    async def test_generate_password_success_three(self) -> None:
+    async def test_routes_generate_password_success_three(self) -> None:
         async with AsyncClient(app=app, base_url=API_URL_BASE) as client:
             response = await client.post(
                 url=URL,
@@ -51,7 +53,7 @@ class TestRoutesSuccessLayer:
             assert response.status_code == 201
 
     @pytest.mark.asyncio
-    async def test_generate_password_success_four(self) -> None:
+    async def test_routes_generate_password_success_four(self) -> None:
         async with AsyncClient(app=app, base_url=API_URL_BASE) as client:
             response = await client.post(
                 url=URL,

--- a/tests/service/test_service_success_layer.py
+++ b/tests/service/test_service_success_layer.py
@@ -14,6 +14,8 @@ from tests.service.generate_password_service import generate_password
 class TestServiceSuccessLayer:
     @pytest.mark.asyncio
     async def test_password_service_success_one(self) -> None:
+        password_one["length"] = 32
+
         new_password = await generate_password(password_one)
 
         assert new_password is not None


### PR DESCRIPTION
- tests: success and errors case base structure
- tests: success generate case methods pre build
- tests: generate password errors layer methods
- tests: generate success layer ready
- tests: generate errors test cases
- fix: problem with index out of range with the keys to switch
- fix: bug with the length key value from a mock object

I just created the cases of success and errors from the lowest layer generate as well as I solved problems the unit tests has found.

But... For some reason my mocks, a dictionary length has changed value when I imported, so I explicitly assign a value to them.
